### PR TITLE
Changing debugging information from "portable" to "pdb-only" to get around issue with pdbcopy

### DIFF
--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.csproj
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DocumentationFile>bin\Release\WindowsDevicePortalWrapper.xml</DocumentationFile>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Change WindowsDevicePortalWrapper > Build > Advanced > Output > Debugging information from "portable" to "pdb-only" to get around issue with pdbcopy